### PR TITLE
Fix File::Copy on non-Windows platforms

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <fstream>
 #include <limits.h>
 #include <string>
 #include <sys/stat.h>
@@ -298,66 +299,22 @@ bool RenameSync(const std::string& srcFilename, const std::string& destFilename)
 	return true;
 }
 
-// copies file srcFilename to destFilename, returns true on success
-bool Copy(const std::string& srcFilename, const std::string& destFilename)
+// copies file source_path to destination_path, returns true on success
+bool Copy(const std::string& source_path, const std::string& destination_path)
 {
-	INFO_LOG(COMMON, "Copy: %s --> %s", srcFilename.c_str(), destFilename.c_str());
+	INFO_LOG(COMMON, "Copy: %s --> %s", source_path.c_str(), destination_path.c_str());
 #ifdef _WIN32
-	if (CopyFile(UTF8ToTStr(srcFilename).c_str(), UTF8ToTStr(destFilename).c_str(), FALSE))
+	if (CopyFile(UTF8ToTStr(source_path).c_str(), UTF8ToTStr(destination_path).c_str(), FALSE))
 		return true;
 
-	ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", srcFilename.c_str(), destFilename.c_str(),
+	ERROR_LOG(COMMON, "Copy: failed %s --> %s: %s", source_path.c_str(), destination_path.c_str(),
 		GetLastErrorMsg().c_str());
 	return false;
 #else
-
-	// buffer size
-#define BSIZE 1024
-
-	char buffer[BSIZE];
-
-	// Open input file
-	std::ifstream input;
-	OpenFStream(input, srcFilename, std::ifstream::in | std::ifstream::binary);
-	if (!input.is_open())
-	{
-		ERROR_LOG(COMMON, "Copy: input failed %s --> %s: %s", srcFilename.c_str(), destFilename.c_str(),
-			GetLastErrorMsg().c_str());
-		return false;
-	}
-
-	// open output file
-	File::IOFile output(destFilename, "wb");
-
-	if (!output.IsOpen())
-	{
-		ERROR_LOG(COMMON, "Copy: output failed %s --> %s: %s", srcFilename.c_str(),
-			destFilename.c_str(), GetLastErrorMsg().c_str());
-		return false;
-	}
-
-	// copy loop
-	while (!input.eof())
-	{
-		// read input
-		input.read(buffer, BSIZE);
-		if (!input)
-		{
-			ERROR_LOG(COMMON, "Copy: failed reading from source, %s --> %s: %s", srcFilename.c_str(),
-				destFilename.c_str(), GetLastErrorMsg().c_str());
-			return false;
-		}
-
-		// write output
-		if (!output.WriteBytes(buffer, BSIZE))
-		{
-			ERROR_LOG(COMMON, "Copy: failed writing to output, %s --> %s: %s", srcFilename.c_str(),
-				destFilename.c_str(), GetLastErrorMsg().c_str());
-			return false;
-		}
-	}
-
-	return true;
+	std::ifstream source{source_path, std::ios::binary};
+	std::ofstream destination{destination_path, std::ios::binary};
+	destination << source.rdbuf();
+	return source.good() && destination.good();
 #endif
 }
 


### PR DESCRIPTION
I'm on Linux (Linux Mint 18.2 MATE, based on Ubuntu 16.04), and I've been trying to get set up with the new PM build from SmashLadder based on Ishiiruka: [PMNetplayV4](https://www.smashladder.com/guides/view/2777/project-m-3-6-sd-v4-bigger-better-faster) (this isn't an officially blessed setup as they only offer downloads and setup instructions for Windows, so I'm flying solo).

After compiling Ishiiruka using [FasterMelee-installer](https://github.com/FasterMelee/FasterMelee-installer), and copying over all of the configuration settings from the Windows PMNetplayV4 download, I was able to load into the game successfully, but would desync whenever I would try to play in Netplay, and the game would even start up differently when I started the game locally versus in a lone Netplay session.

I turned on logging and came across some Dolphin logs like the following:

```
Common/FileUtil.cpp:347 E[COMMON]: Copy: failed reading from source, $DOLPHIN_CONFIG_DIR/Sys/Wii/title/00010000/52534245/data/$SOME_FILE --> /tmp/DolphinWii.aK5pnK/title/00010000/52534245/data/$SOME_FILE: 
```

(I believe these file copies are used for temporary Netplay saves? Not 100% sure about that, but they only seem to happen during Netplay sessions)

After some digging, I came across the `File::Copy` function, which looked... sketchy. `strace` confirmed that there were no errors while reading the file, but instead `File::Copy` was returning an "error" because of an unhandled end-of-file.

Fortunately, dolphin-emu/dolphin#5955 happened, which had a much less sketchy implementation! I cherry-picked the commit, tested out Netplay*, and no more desyncs!

(*Since most players on SmashLadder are using a specific Ishiiruka revision, I applied a patch to manually "spoof" my Dolphin commit revision hash, essentially with the same script that FasterMelee-installer uses)