### PR TITLE
Fixed __Verify_noErr for OSX build

### DIFF
--- a/Externals/wxWidgets3/src/osx/carbon/icon.cpp
+++ b/Externals/wxWidgets3/src/osx/carbon/icon.cpp
@@ -328,7 +328,7 @@ bool wxIcon::LoadIconFromSystemResource(const wxString& resourceName, int desire
     if ( theId != 0 )
     {
         IconRef iconRef = NULL ;
-        verify_noerr( GetIconRef( kOnSystemDisk, kSystemIconsCreator, theId, &iconRef ) ) ;
+        __Verify_noErr( GetIconRef( kOnSystemDisk, kSystemIconsCreator, theId, &iconRef ) ) ;
         if ( iconRef )
         {
             m_refData = new wxIconRefData( (WXHICON) iconRef, desiredWidth, desiredHeight ) ;

--- a/Externals/wxWidgets3/src/osx/carbon/region.cpp
+++ b/Externals/wxWidgets3/src/osx/carbon/region.cpp
@@ -1021,7 +1021,7 @@ bool wxRegion::DoOffset(wxCoord x, wxCoord y)
 
     AllocExclusive();
 
-    verify_noerr( HIShapeOffset( M_REGION , x , y ) ) ;
+    __Verify_noErr( HIShapeOffset( M_REGION , x , y ) ) ;
 
     return true ;
 }
@@ -1076,11 +1076,11 @@ bool wxRegion::DoCombine(const wxRegion& region, wxRegionOp op)
     switch (op)
     {
         case wxRGN_AND:
-            verify_noerr( HIShapeIntersect( M_REGION , OTHER_M_REGION(region) , M_REGION ) );
+            __Verify_noErr( HIShapeIntersect( M_REGION , OTHER_M_REGION(region) , M_REGION ) );
             break ;
 
         case wxRGN_OR:
-            verify_noerr( HIShapeUnion( M_REGION , OTHER_M_REGION(region) , M_REGION ) );
+            __Verify_noErr( HIShapeUnion( M_REGION , OTHER_M_REGION(region) , M_REGION ) );
             break ;
 
         case wxRGN_XOR:
@@ -1088,12 +1088,12 @@ bool wxRegion::DoCombine(const wxRegion& region, wxRegionOp op)
                 // XOR is defined as the difference between union and intersection
                 wxCFRef< HIShapeRef > unionshape( HIShapeCreateUnion( M_REGION , OTHER_M_REGION(region) ) );
                 wxCFRef< HIShapeRef > intersectionshape( HIShapeCreateIntersection( M_REGION , OTHER_M_REGION(region) ) );
-                verify_noerr( HIShapeDifference( unionshape, intersectionshape, M_REGION ) );
+                __Verify_noErr( HIShapeDifference( unionshape, intersectionshape, M_REGION ) );
             }
             break ;
 
         case wxRGN_DIFF:
-            verify_noerr( HIShapeDifference( M_REGION , OTHER_M_REGION(region) , M_REGION ) ) ;
+            __Verify_noErr( HIShapeDifference( M_REGION , OTHER_M_REGION(region) , M_REGION ) ) ;
             break ;
 
         case wxRGN_COPY:

--- a/Externals/wxWidgets3/src/osx/core/bitmap.cpp
+++ b/Externals/wxWidgets3/src/osx/core/bitmap.cpp
@@ -974,7 +974,7 @@ IconRef wxBitmap::GetIconRef() const
 IconRef wxBitmap::CreateIconRef() const
 {
     IconRef icon = GetIconRef();
-    verify_noerr( AcquireIconRef(icon) );
+    __Verify_noErr( AcquireIconRef(icon) );
     return icon;
 }
 #endif


### PR DESCRIPTION
wxWidgets3 was giving me an error for building on my Mac. When `verify_noerr` is changed to `__Verify_noErr` the error disappears.