### PR TITLE
Avoid using PDEP and PEXT on AMD Zen

### DIFF
--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -43,6 +43,9 @@ struct CPUInfo
 	bool bAVX2 = false;
 	bool bBMI1 = false;
 	bool bBMI2 = false;
+	// PDEP and PEXT are ridiculously slow on AMD Zen, so we have this flag to avoid using them there
+	// Zen 2 is also affected by this issue
+	bool bFastBMI2 = false;
 	bool bFMA = false;
 	bool bFMA4 = false;
 	bool bAES = false;

--- a/Source/Core/Common/CPUDetect.h
+++ b/Source/Core/Common/CPUDetect.h
@@ -55,6 +55,7 @@ struct CPUInfo
 	bool bLAHFSAHF64 = false;
 	bool bLongMode = false;
 	bool bAtom = false;
+	bool bZen = false;
 
 	// ARMv8 specific
 	bool bFP = false;

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -110,6 +110,9 @@ void CPUInfo::Detect()
 		if (family == 6 && (model == 0x1C || model == 0x26 || model == 0x27 || model == 0x35 || model == 0x36 ||
 			model == 0x37 || model == 0x4A || model == 0x4D || model == 0x5A || model == 0x5D))
 			bAtom = true;
+		// Detect AMD Zen (all models)
+		if (family == 23)
+			bZen = true;
 		logical_cpu_count = (cpu_id[1] >> 16) & 0xFF;
 		ht = (cpu_id[3] >> 28) & 1;
 

--- a/Source/Core/Common/x64CPUDetect.cpp
+++ b/Source/Core/Common/x64CPUDetect.cpp
@@ -159,6 +159,7 @@ void CPUInfo::Detect()
 	}
 
 	bFlushToZero = bSSE;
+	bFastBMI2 = bBMI2 && !bZen;
 
 	if (max_ex_fn >= 0x80000004)
 	{

--- a/Source/Core/VideoCommon/VertexLoaderX64.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderX64.cpp
@@ -264,7 +264,7 @@ void VertexLoaderX64::ReadColor(OpArg data, u64 attribute, int format)
 		//                   RRRRRGGG GGGBBBBB
 		// AAAAAAAA BBBBBBBB GGGGGGGG RRRRRRRR
 		LoadAndSwap(16, scratch1, data);
-		if (cpu_info.bBMI1 && cpu_info.bBMI2)
+		if (cpu_info.bBMI1 && cpu_info.bFastBMI2)
 		{
 			MOV(32, R(scratch2), Imm32(0x07C3F7C0));
 			PDEP(32, scratch3, scratch1, R(scratch2));
@@ -305,7 +305,7 @@ void VertexLoaderX64::ReadColor(OpArg data, u64 attribute, int format)
 		//                   RRRRGGGG BBBBAAAA
 		// AAAAAAAA BBBBBBBB GGGGGGGG RRRRRRRR
 		LoadAndSwap(16, scratch1, data);
-		if (cpu_info.bBMI2)
+		if (cpu_info.bFastBMI2)
 		{
 			MOV(32, R(scratch2), Imm32(0x0F0F0F0F));
 			PDEP(32, scratch1, scratch1, R(scratch2));
@@ -334,7 +334,7 @@ void VertexLoaderX64::ReadColor(OpArg data, u64 attribute, int format)
 		// AAAAAAAA BBBBBBBB GGGGGGGG RRRRRRRR
 		data.AddMemOffset(-1);
 		LoadAndSwap(32, scratch1, data);
-		if (cpu_info.bBMI2)
+		if (cpu_info.bFastBMI2)
 		{
 			MOV(32, R(scratch2), Imm32(0xFCFCFCFC));
 			PDEP(32, scratch1, scratch1, R(scratch2));


### PR DESCRIPTION
Backport of https://github.com/dolphin-emu/dolphin/pull/8586 and https://github.com/project-slippi/Ishiiruka/pull/24, which explain this PR in more detail.